### PR TITLE
Update iodef.xml

### DIFF
--- a/EXPREF/iodef.xml
+++ b/EXPREF/iodef.xml
@@ -10,7 +10,6 @@
       <variable_definition>
 
           <variable_group id="buffer">
-             <variable id="optimal_buffer_size" type="string">memory</variable>
              <variable id="buffer_size_factor" type="double">2.0</variable>
           </variable_group>
 


### PR DESCRIPTION
removing  "optimal_buffer_size" option as it appears to lead to the model hanging in the initialisation of XIOS on ARCHER2